### PR TITLE
Stop installing typing on Python 3.5+

### DIFF
--- a/requirements/pypi.txt
+++ b/requirements/pypi.txt
@@ -8,7 +8,7 @@
 # should see if there is a conda package that suits your needs.
 
 pathlib2
-typing
+typing; python_version < "3.5"
 click
 toml
 six


### PR DESCRIPTION
Installing https://pypi.org/project/typing/ is not needed on Python 3.5+. Additionally, a [bug in pip](https://github.com/pypa/pip/issues/8272) means that having `typing` from PyPI breaks some commands on Python 3.7 and 3.8. Our only dependency that installed typing inconditionally is pycalver, so this pull request fixes the issue.

Thanks!